### PR TITLE
Re-enable the local CRAN variant

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -38,14 +38,12 @@
     ## Initialize an empty local CRAN repository.
     ## Note: In this setup, we are not placing package
     ## sources or binaries into this location.
-
-    # local_user_cran = file.path(Sys.getenv("HOME"), "cran")
-    # dir.create(local_user_cran, showWarnings = FALSE)
+    local_user_cran = file.path(Sys.getenv("HOME"), "cran")
+    dir.create(local_user_cran, showWarnings = FALSE)
 
     ## Set the location of packages to the empty local CRAN.
     ## Ensure that the appropriate RStudio Secure warning is handled.
-
-    # options(repos = c("CRAN" = paste0("file://", local_user_cran)))
+    options(repos = c("CRAN" = paste0("file://", local_user_cran)))
 
     ## CBTF Help Messages ----
 

--- a/.Rprofile
+++ b/.Rprofile
@@ -113,8 +113,14 @@
         base::lockBinding(name, env)
     }
 
-    ## Rewrite install.packages
-    shim_pkg_func("install.packages", "utils", function(...) { cbtf_disabled_cran_msg() })
+    ## Provide an alternative install.packages(...) routine
+    install_packages_shim = function(...) { cbtf_disabled_cran_msg() }
+
+    ## Setup a shim
+    ##
+    ## Note: RStudio will overwrite the shim due to the initialization procedure.
+    ## Only valid in _R_ terminal sessions or R GUI.
+    shim_pkg_func("install.packages", "utils", install_packages_shim)
 
     ## Display the welcome bumper
     cbtf_welcome_msg()

--- a/.Rprofile
+++ b/.Rprofile
@@ -103,17 +103,14 @@
         env = as.environment(pkg_env_name)
         #pkg_ns_env = asNamespace(pkgname)
 
-        # Retrieve symbolic value of function/value to be replaced
-        sym = as.symbol(name)
-
         # Unlock environment where the function/variable is found.
-        base:::unlockBinding(sym, env)
+        base::unlockBinding(name, env)
 
         # Make the assignment into the environment with the new value
-        base:::assign(name, value, envir = env)
+        base::assign(name, value, envir = env)
 
         # Close the environment
-        base:::lockBinding(sym, env)
+        base::lockBinding(name, env)
     }
 
     ## Rewrite install.packages

--- a/.Rprofile
+++ b/.Rprofile
@@ -48,8 +48,9 @@
     ## CBTF Help Messages ----
 
     ## Hard coded help documentation location
-    cbtf_help_url = "https://cbtf.engr.illinois.edu/home.html"
     ## TODO: Update to where docs are on the CBTF website!!
+
+    cbtf_help_url = "https://cbtf.engr.illinois.edu/home.html"
 
     ## Open the URL for students to view help documentation
     help_cbtf = function(url = cbtf_help_url) {

--- a/setup-centos7-r.sh
+++ b/setup-centos7-r.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# r-centos7-install.sh
+# setup-centos7-r.sh
 #
 # Copyright (C) 2019 James Joseph Balamuta <balamut2@illinois.edu>
 #
@@ -24,10 +24,10 @@
 
 ######################################
 # # Allow the file to execute
-# chmod +x ~/r-centos7-install.sh
+# chmod +x ~/setup-centos7-r.sh
 #
 # # Run the file
-# ./r-centos7-install.sh
+# ./setup-centos7-r.sh
 ######################################
 
 ############## Add Development Tools


### PR DESCRIPTION
In this PR, we:

- Re-enabled the local CRAN mirror redirect.
    - We initially disabled the local mirror to try and debug why _RStudio_ wasn't matching the same behavior as _R_'s console / GUI. 
- Changed the shim to directly use character names instead of symbols. 
- Renamed the bootstrap script to `setup-centos7-r.sh` to emphasize environment setup.

### Self-notes: 

In particular, the errors were:

- Loudly with a local CRAN and package shim set
![bogus-cran-mirror](https://user-images.githubusercontent.com/833642/54858784-052b9c80-4cd5-11e9-9111-7d76edf3f861.png)
- Silently without a local CRAN mirror set in `.Rprofile`:
![rstudio-hook-install-pkg-delay](https://user-images.githubusercontent.com/833642/54858802-2096a780-4cd5-11e9-8bc3-f99ae704d665.gif)
- Perfect in _R_ console and GUI:
![r-build-fine](https://user-images.githubusercontent.com/833642/54858728-a9f9aa00-4cd4-11e9-8918-bcd6979cb3c9.png)
