### PR TITLE
Package Installation shim for RStudio

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -76,8 +76,8 @@
 
     cbtf_disabled_cran_msg = function() {
         message("Note: ")
-        message(strwrap("Installing packages from CRAN is disabled."))
-        message(strwrap("All required R packages have already been installed.\n"))
+        wrap_msg("Installing packages from CRAN is disabled.")
+        wrap_msg("All required R packages have already been installed.\n")
     }
 
     cbtf_documentation_msg = function() {

--- a/.Rprofile
+++ b/.Rprofile
@@ -70,6 +70,10 @@
     ## Provide startup messages in red text to indicate the status of
     ## package installation and environment specific documentation
 
+    wrap_msg = function(x) {
+        message(paste(strwrap(x), collapse = "\n"))
+    }
+
     cbtf_disabled_cran_msg = function() {
         message("Note: ")
         message(strwrap("Installing packages from CRAN is disabled."))
@@ -77,13 +81,7 @@
     }
 
     cbtf_documentation_msg = function() {
-        message(
-            strwrap(
-                paste0("For help with R and RStudio in the CBTF, please consult",
-                       " the help guide by using the `help_cbtf()` function.")
-                , prefix = "\n"
-            )
-        )
+        wrap_msg("For help with R and RStudio in the CBTF, please consult the help guide by using the `help_cbtf()` function.")
     }
 
     cbtf_welcome_msg = function() {

--- a/.Rprofile
+++ b/.Rprofile
@@ -77,7 +77,9 @@
     cbtf_disabled_cran_msg = function() {
         message("Note: ")
         wrap_msg("Installing packages from CRAN is disabled.")
-        wrap_msg("All required R packages have already been installed.\n")
+        wrap_msg(
+            "Packages required by STAT 385, STAT 430 DSPM, STAT 432, and CE 202 have been pre-installed. \n"
+        )
     }
 
     cbtf_documentation_msg = function() {


### PR DESCRIPTION
This PR uses the `sessionInit` hook for RStudio in `.Rprofile` to override their custom `install.packages()` shim. Details of the hook system can be found at: 

https://github.com/rstudio/rstudio/issues/1579#issuecomment-495706255

![Screen Shot 2019-08-30 at 11 10 49 AM](https://user-images.githubusercontent.com/833642/64035617-dc76c100-cb16-11e9-9f61-7968a349e092.png)